### PR TITLE
Require indentation of switch blocks

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,8 @@
     "no-console": 0,
     "indent": [
       2,
-      2
+      2,
+      {"SwitchCase": 1}
     ],
     "quotes": [
       2,


### PR DESCRIPTION
If folks are using a Case statement, the switch blocks should be indented... right?